### PR TITLE
Tweak constructors to bless lexicals

### DIFF
--- a/lib/Data/Perl/Counter.pm
+++ b/lib/Data/Perl/Counter.pm
@@ -4,7 +4,7 @@ package Data::Perl::Counter;
 
 use strictures 1;
 
-sub new { my $cl = shift; bless \$_[0], $cl }
+sub new { bless \(my $n = $_[1]), $_[0] }
 
 sub inc { ${$_[0]} += ($_[1] ? $_[1] : 1) }
 

--- a/lib/Data/Perl/Number.pm
+++ b/lib/Data/Perl/Number.pm
@@ -4,7 +4,7 @@ package Data::Perl::Number;
 
 use strictures 1;
 
-sub new { bless(\$_[1], $_[0]) }
+sub new { bless \(my $n = $_[1]), $_[0] }
 
 sub add { ${$_[0]} = ${$_[0]} + $_[1] }
 

--- a/lib/Data/Perl/String.pm
+++ b/lib/Data/Perl/String.pm
@@ -4,7 +4,7 @@ package Data::Perl::String;
 
 use strictures 1;
 
-sub new { my $cl = shift; bless(\$_[0], $cl) }
+sub new { bless \(my $s = $_[1]), $_[0] }
 
 sub inc { ${$_[0]}++ }
 


### PR DESCRIPTION
(perl 5.16.0) Certain constructors seem to balk at blessing \$_[1] and similar here:

 t/counter.t .. Modification of a read-only value attempted
  ... etc ...

This change tweaks constructors for Counter, Number, and String to always bless a lexical, which results in passing tests here.

modified:   lib/Data/Perl/Counter.pm
    modified:   lib/Data/Perl/Number.pm
    modified:   lib/Data/Perl/String.pm
