### PR TITLE
Make it easier to subclass the collection classes

### DIFF
--- a/lib/Data/Perl/Collection/Hash.pm
+++ b/lib/Data/Perl/Collection/Hash.pm
@@ -6,12 +6,13 @@ use strictures 1;
 
 use Scalar::Util qw/blessed/;
 use Data::Perl::Collection::Array;
+use constant _array_class => 'Data::Perl::Collection::Array';
 
 sub new { my $cl = shift; bless({ @_ }, $cl) }
 
 sub get {
   my $self = shift;
-  @_ > 1 ? Data::Perl::Collection::Array->new(@{$self}{@_}) : $self->{$_[0]}
+  @_ > 1 ? $self->_array_class->new(@{$self}{@_}) : $self->{$_[0]}
 }
 
 sub set {
@@ -22,7 +23,7 @@ sub set {
   @{$self}{@_[@keys_idx]} = @_[@values_idx];
 
   if (wantarray) {
-    return Data::Perl::Collection::Array->new(@{$self}{@_[@keys_idx]});
+    return $self->_array_class->new(@{$self}{@_[@keys_idx]});
   }
   else {
     return $self->{$_[$keys_idx[0]]};
@@ -32,10 +33,10 @@ sub set {
 sub delete {
   my $self = shift;
   my @deleted = CORE::delete @{$self}{@_};
-  wantarray ? Data::Perl::Collection::Array->new(@deleted) : $deleted[-1];
+  wantarray ? $self->_array_class->new(@deleted) : $deleted[-1];
 }
 
-sub keys { Data::Perl::Collection::Array->new(keys %{$_[0]}) }
+sub keys { $_[0]->_array_class->new(keys %{$_[0]}) }
 
 sub exists { CORE::exists $_[0]->{$_[1]} }
 
@@ -43,9 +44,9 @@ sub defined { CORE::defined $_[0]->{$_[1]} }
 
 sub values { CORE::values %{$_[0]} }
 
-sub kv { Data::Perl::Collection::Array->new(CORE::map { [ $_, $_[0]->{$_} ] } CORE::keys %{$_[0]}) }
+sub kv { $_[0]->_array_class->new(CORE::map { [ $_, $_[0]->{$_} ] } CORE::keys %{$_[0]}) }
 
-sub elements { Data::Perl::Collection::Array->new(CORE::map { $_, $_[0]->{$_} } CORE::keys %{$_[0]}) }
+sub elements { $_[0]->_array_class->new(CORE::map { $_, $_[0]->{$_} } CORE::keys %{$_[0]}) }
 
 sub clear { ref($_[0])->new(%{$_[0]} = ()) }
 
@@ -83,7 +84,8 @@ __END__
 =head1 DESCRIPTION
 
 This class provides a wrapper and methods for interacting with a hash.
-All methods that return a list do so via a Data::Perl::Collection::Array object.
+All methods that return a list do so via a Data::Perl::Collection::Array
+object.
 
 =head1 PROVIDED METHODS
 
@@ -192,6 +194,13 @@ This method returns a shallow clone of the hash reference.  The return value
 is a reference to a new hash with the same keys and values.  It is I<shallow>
 because any values that were references in the original will be the I<same>
 references in the clone.
+
+=item B<_array_class>
+
+The name of the class which returned lists are instances of; i.e.
+C<< Data::Perl::Collection::Array >>.
+
+Subclasses of this class can override this method.
 
 =back
 

--- a/t/collection/subclassing.t
+++ b/t/collection/subclassing.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Data::Perl;
+
+BEGIN {
+	package Local::Array;
+	use parent 'Data::Perl::Collection::Array';
+	sub monkey_around {
+		my $self = shift;
+		ref($self)->new(map "Bonobo", @$self);
+	}
+};
+
+BEGIN {
+	package Local::Hash;
+	use parent 'Data::Perl::Collection::Hash';
+	use constant _array_class => "Local::Array";
+};
+
+my $hash = Local::Hash->new(a => 1, b => 2);
+
+isa_ok(
+	$hash->keys,
+	'Data::Perl::Collection::Array',
+	'hash keys are an array',
+);
+
+isa_ok(
+	$hash->keys,
+	'Local::Array',
+	'hash keys are our subclass of array',
+);
+
+can_ok(
+	$hash->keys,
+	'monkey_around',
+);
+
+is_deeply(
+	$hash->keys->monkey_around,
+	Local::Array->new(qw/ Bonobo Bonobo /),
+	'our custom method works',
+);
+
+done_testing;


### PR DESCRIPTION
This removes hard-coded references to Data::Perl::Collection::Array within Data::Perl::Collection::Hash, replacing them with `$self->_array_class`.

People subclassing Data::Perl::Collection::Hash can override `_array_class`.
